### PR TITLE
feat: derive color by shifting lightness

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ tags: ["hugo", "theme"]
 
 ## Color Scheme
 
-The theme uses a paper-like color palette, use a background primary color as base and then derive the rest of theme colors by shifting lightness (or saturation/hue if needed) relative to that base, so we can easily generate multiple variants (light, dark, high-contrast, etc.). Therefore, you can adjust just base color and keep the same vibe, checkout [#3](https://github.com/ntk148v/shibui/pull/3) for preview.
+The theme uses a paper-like color palette, use a background primary color as base and then derive the rest of theme colors by shifting lightness (or saturation/hue if needed) relative to that base, so we can easily generate multiple variants (light, dark, high-contrast, etc.). Therefore, you can adjust just base color and keep the same vibe, checkout [#4](https://github.com/ntk148v/shibui/pull/4) for preview.
 
 ```css
 /* Base theme knobs */

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Table of contents:
 - Mobile-responsive layout
 - Table of Contents support
 - Tags support
+- Customizable
 
 ## Installation
 
@@ -105,17 +106,35 @@ tags: ["hugo", "theme"]
 
 ## Color Scheme
 
-The theme uses a paper-like color palette:
+The theme uses a paper-like color palette, use a background primary color as base and then derive the rest of your theme colors by shifting lightness (or saturation/hue if needed) relative to that base, so you can easily generate multiple variants (light, dark, high-contrast, etc.). Therefore, you can adjust just base color and keep the same vibe, checkout [#3](https://github.com/ntk148v/shibui/pull/3) for preview.
 
 ```css
-/* Colors */
---color-bg-primary: hsl(0, 0%, 99%);
---color-bg-secondary: hsl(0, 0%, 97.3%);
---color-border: hsl(0, 0%, 93%);
---color-text-primary: hsl(0, 0%, 9%);
---color-text-muted: hsl(0, 0%, 43.5%);
---color-text-code: hsl(0, 0%, 20%);
---color-selection-bg: hsl(0, 0%, 85.8%);
+/* Base theme knobs */
+--bg-h: 0;
+--bg-s: 0%;
+--bg-l: 99%;
+
+/* Background colors */
+--color-bg-primary: hsl(var(--bg-h) var(--bg-s) var(--bg-l));
+--color-bg-secondary: hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) - 2%));
+--color-border: hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) - 6%));
+--color-selection-bg: hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) - 13%));
+
+/* Text colors with WCAG-friendly contrast */
+/* Primary: ensures near-black on light bg and near-white on dark bg */
+--color-text-primary: hsl(
+  var(--bg-h) var(--bg-s) clamp(8%, calc(100% - var(--bg-l)), 92%)
+);
+
+/* Muted: softer but still >4.5:1 contrast */
+--color-text-muted: hsl(
+  var(--bg-h) var(--bg-s) clamp(30%, calc(85% - var(--bg-l)), 75%)
+);
+
+/* Code text: slightly brighter than muted */
+--color-text-code: hsl(
+  var(--bg-h) var(--bg-s) clamp(20%, calc(90% - var(--bg-l)), 85%)
+);
 ```
 
 ## Customization
@@ -124,22 +143,14 @@ The theme uses a paper-like color palette:
 
 You can customize the theme by overriding CSS variables in your `assets/css/custom.css`:
 
+For example, you want to create a dark theme, just adjust the base color.
+
 ```css
 :root {
-  /* Typography */
-  --spacing-base: 1.5em;          /* Base line height and spacing unit */
-  --font-family-mono: monospace;  /* Base monospace font */
-  --font-size-base: 1em;         /* Base font size */
-  --font-size-small: 0.9em;      /* Small text size */
-
-  /* Colors */
-  --color-bg-primary: hsl(0, 0%, 99%);
-  --color-bg-secondary: hsl(0, 0%, 97.3%);
-  --color-border: hsl(0, 0%, 93%);
-  --color-text-primary: hsl(0, 0%, 9%);
-  --color-text-muted: hsl(0, 0%, 43.5%);
-  --color-text-code: hsl(0, 0%, 20%);
-  --color-selection-bg: hsl(0, 0%, 85.8%);
+  /* Base theme knobs */
+  --bg-h: 0;
+  --bg-s: 0%;
+  --bg-l: 12%;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ tags: ["hugo", "theme"]
 
 ## Color Scheme
 
-The theme uses a paper-like color palette, use a background primary color as base and then derive the rest of your theme colors by shifting lightness (or saturation/hue if needed) relative to that base, so you can easily generate multiple variants (light, dark, high-contrast, etc.). Therefore, you can adjust just base color and keep the same vibe, checkout [#3](https://github.com/ntk148v/shibui/pull/3) for preview.
+The theme uses a paper-like color palette, use a background primary color as base and then derive the rest of theme colors by shifting lightness (or saturation/hue if needed) relative to that base, so we can easily generate multiple variants (light, dark, high-contrast, etc.). Therefore, you can adjust just base color and keep the same vibe, checkout [#3](https://github.com/ntk148v/shibui/pull/3) for preview.
 
 ```css
 /* Base theme knobs */

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,1 @@
+/* You can add custom style here */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -12,14 +12,32 @@
   --spacing-md: var(--spacing-base);
   --spacing-lg: calc(var(--spacing-base) * 2);
 
-  /* Colors */
-  --color-bg-primary: hsl(0, 0%, 99%);
-  --color-bg-secondary: hsl(0, 0%, 97.3%);
-  --color-border: hsl(0, 0%, 93%);
-  --color-text-primary: hsl(0, 0%, 9%);
-  --color-text-muted: hsl(0, 0%, 43.5%);
-  --color-text-code: hsl(0, 0%, 20%);
-  --color-selection-bg: hsl(0, 0%, 85.8%);
+  /* Base theme knobs */
+  --bg-h: 0;
+  --bg-s: 0%;
+  --bg-l: 99%;
+
+  /* Background colors */
+  --color-bg-primary: hsl(var(--bg-h) var(--bg-s) var(--bg-l));
+  --color-bg-secondary: hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) - 2%));
+  --color-border: hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) - 6%));
+  --color-selection-bg: hsl(var(--bg-h) var(--bg-s) calc(var(--bg-l) - 13%));
+
+  /* Text colors with WCAG-friendly contrast */
+  /* Primary: ensures near-black on light bg and near-white on dark bg */
+  --color-text-primary: hsl(
+    var(--bg-h) var(--bg-s) clamp(8%, calc(100% - var(--bg-l)), 92%)
+  );
+
+  /* Muted: softer but still >4.5:1 contrast */
+  --color-text-muted: hsl(
+    var(--bg-h) var(--bg-s) clamp(30%, calc(85% - var(--bg-l)), 75%)
+  );
+
+  /* Code text: slightly brighter than muted */
+  --color-text-code: hsl(
+    var(--bg-h) var(--bg-s) clamp(20%, calc(90% - var(--bg-l)), 85%)
+  );
 
   /* Layout */
   --container-width: 64ch;
@@ -65,7 +83,7 @@
   margin: 0;
   padding: 0;
   font: inherit;
-  color: inherit;
+  color: var(--color-text-primary);
   box-sizing: border-box;
 }
 
@@ -254,7 +272,7 @@ h5 > code {
 .path-nav li {
   display: flex;
   align-items: center;
-  color: #888;
+  color: var(--color-text-muted);
   flex-shrink: 0;
   max-width: 200px; /* Limit maximum width on small screens */
 }
@@ -270,10 +288,11 @@ h5 > code {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--color-text-muted);
 }
 
 .path-nav li.current a {
-  color: #000;
+  color: var(--color-text-primary);
 }
 
 .path-nav a:hover {
@@ -285,12 +304,12 @@ h5 > code {
 }
 
 .back-link {
-  color: #888;
+  color: var(--color-text-muted);
   border-bottom: none;
 }
 
 .back-link:hover {
-  color: #000;
+  color: var(--color-text-primary);
   text-decoration: none;
 }
 
@@ -445,7 +464,7 @@ blockquote > :last-child {
 .toc .toc-content a {
   text-decoration: none;
   color: var(--color-text-primary);
-  font-size: var(--font-size-small)
+  font-size: var(--font-size-small);
 }
 
 .toc .toc-content ol li {
@@ -475,3 +494,6 @@ blockquote > :last-child {
     max-width: calc(100vw - 4em);
   }
 }
+
+/* Custom defined styles */
+@import "assets/css/custom";

--- a/layouts/_partials/head/css.html
+++ b/layouts/_partials/head/css.html
@@ -7,3 +7,13 @@
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{- with resources.Get "css/custom.css" }}
+  {{- if hugo.IsDevelopment }}
+    <link rel="stylesheet" href="{{ .RelPermalink }}">
+  {{- else }}
+    {{- with . | minify | fingerprint }}
+      <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
+    {{- end }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

I use a base color (`--color-bg-primary`) and then derive the rest of theme colors by shifting lightness (or saturation/hue if needed) relative to that base, so we can easily generate multiple variants (light, dark, high-contrast, etc.)

## Preview

There is custom.css content and how the theme look like.

1. Dark theme

```css
:root {
  /* Base theme knobs */
  --bg-h: 0;
  --bg-s: 0%;
  --bg-l: 12%;
}
```

<img width="1792" height="896" alt="image" src="https://github.com/user-attachments/assets/3312872b-c1d8-4fec-90ad-8e3be417210e" />
<img width="1461" height="755" alt="image" src="https://github.com/user-attachments/assets/c78df9a4-88dd-44a7-bb99-93369f0c2519" />

2. Pink theme

```css
:root {
  /* Base theme knobs */
  --bg-h: 341;
  --bg-s: 100%;
  --bg-l: 91%;
}
```

<img width="1727" height="899" alt="image" src="https://github.com/user-attachments/assets/8f06e66a-9dc7-4b6a-945b-eef7f77273e4" />
<img width="1743" height="881" alt="image" src="https://github.com/user-attachments/assets/61456011-f609-4f19-a3e0-2d7a7f91de28" />

3. The previous paper-like theme

```css
:root {
  /* Base theme knobs */
  --bg-h: 341;
  --bg-s: 100%;
  --bg-l: 91%;
}
```

<img width="1802" height="887" alt="image" src="https://github.com/user-attachments/assets/87be90c5-525a-40cf-adf7-9de5e1b2da74" />
<img width="1782" height="885" alt="image" src="https://github.com/user-attachments/assets/eb0f4108-6cbc-4b76-b1e0-852be8ad3e61" />

## Side effect?

I accidentally delete the import custom.css file in the main one. Therefore, the customization logic doesn't work, this PR also bring it back and solve #3. 